### PR TITLE
:sparkles: 탈퇴회원 관련사항 반영

### DIFF
--- a/src/main/java/com/boggle_boggle/bbegok/controller/UserController.java
+++ b/src/main/java/com/boggle_boggle/bbegok/controller/UserController.java
@@ -22,7 +22,7 @@ public class UserController {
     private final UserService userService;
 
     //회원탈퇴
-    @PatchMapping("/")
+    @DeleteMapping
     public DataResponseDto<Null> deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
         userService.deleteUser(userDetails.getUsername());
         return DataResponseDto.empty();

--- a/src/main/java/com/boggle_boggle/bbegok/entity/user/User.java
+++ b/src/main/java/com/boggle_boggle/bbegok/entity/user/User.java
@@ -24,7 +24,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userSeq;
 
-    @Column(name = "user_id", length = 64, unique = true)
+    @Column(name = "user_id", length = 64)
     @NotNull
     @Size(max = 64)
     private String userId;
@@ -111,6 +111,7 @@ public class User {
     public void softDelete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+        this.updateNickName(null);
     }
 
     public void updateGuestToUser(String latestVersion) {

--- a/src/main/java/com/boggle_boggle/bbegok/exception/Code.java
+++ b/src/main/java/com/boggle_boggle/bbegok/exception/Code.java
@@ -42,6 +42,7 @@ public enum Code {
 
     // 사용자 관련 예외
     USER_NOT_FOUND(13000, HttpStatus.NOT_FOUND, "User not found"),
+    USER_ALREADY_WITHDRAWN(13001, HttpStatus.FORBIDDEN, "The user has already withdrawn from the service"),
     DUPLICATE_USERNAME(13001, HttpStatus.CONFLICT, "Username already exists"),
     INVALID_PASSWORD(13002, HttpStatus.BAD_REQUEST, "Invalid password format"),
 

--- a/src/main/java/com/boggle_boggle/bbegok/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/boggle_boggle/bbegok/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -110,7 +110,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         Optional<UserRefreshToken> userRefreshToken = userRefreshTokenRepository.findByUser_UserIdAndDeviceId(userInfo.getId(), deviceId);
         if (userRefreshToken.isPresent()) userRefreshToken.get().updateRefreshToken(refreshToken.getToken());
         else {
-            User userEntity = userRepository.findByUserId(userInfo.getId());
+            User userEntity = userRepository.findByUserIdAndIsDeleted(userInfo.getId(), false);
             UserRefreshToken newUserRefreshToken = UserRefreshToken.createUserRefreshToken(userEntity,
                     refreshToken.getToken(), deviceId);
             userRefreshTokenRepository.saveAndFlush(newUserRefreshToken);

--- a/src/main/java/com/boggle_boggle/bbegok/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/oauth/service/CustomOAuth2UserService.java
@@ -47,7 +47,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User user) {
         ProviderType providerType = ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
         String userId = user.getName(); //OAuth2에서 제공하는 고유식별자
-        User savedUser = userRepository.findByUserId(userId);
+        User savedUser = userRepository.findByUserIdAndIsDeleted(userId, false);
 
         if (savedUser != null) { //서로 다른 인증제공자간 충돌을 방지
             if (providerType != savedUser.getProviderType()) {
@@ -58,10 +58,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             }
             //기존 가입자에게 셋팅정보가 없다면 생성
             if(userSettingsRepository.findByUser(savedUser) == null) userSettingsRepository.saveAndFlush(UserSettings.createUserSettings(savedUser));
-
-
-
-        } else { //가입한적 없다면 회원가입을 진행.
+        } else {
+            //가입한적 없다면 회원가입을 진행.
             savedUser = createUser(userId, providerType);
             userSettingsRepository.saveAndFlush(UserSettings.createUserSettings(savedUser));
         }

--- a/src/main/java/com/boggle_boggle/bbegok/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/oauth/service/CustomUserDetailsService.java
@@ -16,10 +16,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUserId(username);
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findByUserIdAndIsDeleted(userId, false);
         if (user == null) {
-            throw new UsernameNotFoundException("Can not find username.");
+            throw new UsernameNotFoundException("Can not find User.");
         }
         return UserPrincipal.create(user);
     }

--- a/src/main/java/com/boggle_boggle/bbegok/repository/redis/SearchLogRepository.java
+++ b/src/main/java/com/boggle_boggle/bbegok/repository/redis/SearchLogRepository.java
@@ -24,8 +24,8 @@ public class SearchLogRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void saveRecentSearchLog(String userId, String keyword) {
-        String key = KEY_PREFIX + userId;
+    public void saveRecentSearchLog(Long userSeq, String keyword) {
+        String key = KEY_PREFIX + userSeq;
 
         // 현재 시간을 점수로 설정
         long score = System.currentTimeMillis();
@@ -40,7 +40,7 @@ public class SearchLogRepository {
         }
     }
 
-    public List<String> getRecentSearchLogs(String userId) {
+    public List<String> getRecentSearchLogs(Long userId) {
         String key = KEY_PREFIX + userId;
 
         // 최근 검색어를 점수 기준으로 내림차순 조회
@@ -51,7 +51,7 @@ public class SearchLogRepository {
         return resultSet != null ? new ArrayList<>(resultSet) : Collections.emptyList();
     }
 
-    public void deleteRecentSearchLog(String userId, String keyword) {
+    public void deleteRecentSearchLog(Long userId, String keyword) {
         String key = KEY_PREFIX + userId;
 
         // 검색어 삭제
@@ -63,7 +63,7 @@ public class SearchLogRepository {
         }
     }
 
-    public void deleteAllRecentSearchLog(String userId) {
+    public void deleteAllRecentSearchLog(Long userId) {
         String key = KEY_PREFIX + userId;
 
         // 리스트 존재 여부 확인

--- a/src/main/java/com/boggle_boggle/bbegok/repository/user/UserRepository.java
+++ b/src/main/java/com/boggle_boggle/bbegok/repository/user/UserRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByUserId(String userId);
+    User findByUserIdAndIsDeleted(String userId, boolean isDeleted);
 
     Optional<User> findByUserName(String nickname);
 

--- a/src/main/java/com/boggle_boggle/bbegok/service/AccessTokenService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/AccessTokenService.java
@@ -30,7 +30,7 @@ public class AccessTokenService {
                     new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
             );
         } else { //roleType == RoleType.USER -> 해당 user가 최신약관의 필수항목에 모두 동의하지 않았다면 LIMITED_USER를 반환함
-            User userEntity = userRepository.findByUserId(userId);
+            User userEntity = userRepository.findByUserIdAndIsDeleted(userId, false);
             String recentUpdatedVersion = termsRepository.getLatestTermsVersion();
 
             RoleType newRoleType;

--- a/src/main/java/com/boggle_boggle/bbegok/service/LibraryService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/LibraryService.java
@@ -41,7 +41,9 @@ public class LibraryService {
     private final ReadingRecordRepository readingRecordRepository;
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     public Sort getSortWithReadingRecordToLibraryMapping(User user) {

--- a/src/main/java/com/boggle_boggle/bbegok/service/MyPageService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/MyPageService.java
@@ -5,6 +5,8 @@ import com.boggle_boggle.bbegok.dto.response.MyPageResponse;
 import com.boggle_boggle.bbegok.entity.ReadingRecord;
 import com.boggle_boggle.bbegok.entity.user.User;
 import com.boggle_boggle.bbegok.enums.ReadStatus;
+import com.boggle_boggle.bbegok.exception.Code;
+import com.boggle_boggle.bbegok.exception.exception.GeneralException;
 import com.boggle_boggle.bbegok.repository.NoteRepository;
 import com.boggle_boggle.bbegok.repository.ReadingRecordRepository;
 import com.boggle_boggle.bbegok.repository.user.UserRepository;
@@ -22,7 +24,9 @@ public class MyPageService {
     private final NoteRepository noteRepository;
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     public MyPageResponse getMyPage(String userId) {

--- a/src/main/java/com/boggle_boggle/bbegok/service/NoteService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/NoteService.java
@@ -107,7 +107,9 @@ public class NoteService {
     //== 사용할 기타 메소드
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     private ReadingRecord findReadingRecord(Long id, String userId){

--- a/src/main/java/com/boggle_boggle/bbegok/service/ReadingRecordService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/ReadingRecordService.java
@@ -36,7 +36,9 @@ public class ReadingRecordService {
     private final BookService bookService;
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     private void validationNewReadingRecordRequest(NewReadingRecordRequest request) {

--- a/src/main/java/com/boggle_boggle/bbegok/service/SearchLogService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/SearchLogService.java
@@ -1,6 +1,10 @@
 package com.boggle_boggle.bbegok.service;
 
+import com.boggle_boggle.bbegok.entity.user.User;
+import com.boggle_boggle.bbegok.exception.Code;
+import com.boggle_boggle.bbegok.exception.exception.GeneralException;
 import com.boggle_boggle.bbegok.repository.redis.SearchLogRepository;
+import com.boggle_boggle.bbegok.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,20 +16,27 @@ import java.util.List;
 @Transactional
 public class SearchLogService {
     private final SearchLogRepository searchLogRepository;
+    private final UserRepository userRepository;
+
+    public User getUser(String userId) {
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
+    }
 
     public List<String> getRecentSearchLogs(String userId) {
-        return searchLogRepository.getRecentSearchLogs(userId);
+        return searchLogRepository.getRecentSearchLogs(getUser(userId).getUserSeq());
     }
 
     public void saveRecentSearchLogs(String userId, String keyword) {
-        searchLogRepository.saveRecentSearchLog(userId, keyword);
+        searchLogRepository.saveRecentSearchLog(getUser(userId).getUserSeq(), keyword);
     }
 
     public void deleteRecentSearchLog(String userId, String keyword) {
-        searchLogRepository.deleteRecentSearchLog(userId, keyword);
+        searchLogRepository.deleteRecentSearchLog(getUser(userId).getUserSeq(), keyword);
     }
 
     public void deleteAllRecentSearchLog(String userId) {
-        searchLogRepository.deleteAllRecentSearchLog(userId);
+        searchLogRepository.deleteAllRecentSearchLog(getUser(userId).getUserSeq());
     }
 }

--- a/src/main/java/com/boggle_boggle/bbegok/service/UserService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/UserService.java
@@ -31,7 +31,9 @@ public class UserService {
     private final UserRefreshTokenRepository userRefreshTokenRepository;
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     //Soft Delete를 위해 User컬럼 업데이트 및 토큰DB 삭제처리

--- a/src/main/java/com/boggle_boggle/bbegok/service/UserSettingsService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/UserSettingsService.java
@@ -3,6 +3,8 @@ package com.boggle_boggle.bbegok.service;
 import com.boggle_boggle.bbegok.entity.user.User;
 import com.boggle_boggle.bbegok.entity.user.UserSettings;
 import com.boggle_boggle.bbegok.enums.SortingType;
+import com.boggle_boggle.bbegok.exception.Code;
+import com.boggle_boggle.bbegok.exception.exception.GeneralException;
 import com.boggle_boggle.bbegok.repository.user.UserRepository;
 import com.boggle_boggle.bbegok.repository.user.UserSettingsRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,9 @@ public class UserSettingsService {
     private final UserRepository userRepository;
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId);
+        if(user.getIsDeleted()) throw new GeneralException(Code.USER_ALREADY_WITHDRAWN);
+        return user;
     }
 
     public String getSortingType(String userId) {


### PR DESCRIPTION
- 탈퇴한 회원에 대한 에러코드 추가
- 탈퇴시 회원 컬럼 업데이트 & DB에서 Refresh토큰 삭제
- 기존 Repository에 User에 관한 활성화 조건 추가
- getUser에서 탈퇴회원의 경우 Error Exception 추가
- Redis의 key값을 userId가 아닌 userSeq 활용하도록 리팩토링
- 로그인/회원가입 로직에서 탈퇴된 회원을 제외하고 검색