### PR TITLE
:bug: 독서노트 수정시 validation 수정

### DIFF
--- a/src/main/java/com/boggle_boggle/bbegok/service/NoteService.java
+++ b/src/main/java/com/boggle_boggle/bbegok/service/NoteService.java
@@ -93,6 +93,16 @@ public class NoteService {
         return true;
     }
 
+    public boolean validateUpdateNote(NewNoteRequest request) {
+        if(request.getPages().isPresent()) {
+            if(request.getPages().get() != null) {
+                if((request.getPages().get().getStartPage() < 1 || request.getPages().get().getStartPage()>99999)) return false;
+                if((request.getPages().get().getEndPage() < 1 || request.getPages().get().getEndPage()>99999)) return false;
+            }
+        }
+        return true;
+    }
+
     public Long saveNote(Long recordId, NewNoteRequest request, String userSeq) {
         if(!validateNote(request)) throw new GeneralException(Code.BAD_REQUEST);
 
@@ -103,7 +113,7 @@ public class NoteService {
     }
 
     public void updateNote(Long recordId, Long noteId, NewNoteRequest request, String userSeq) {
-        if(!validateNote(request)) throw new GeneralException(Code.BAD_REQUEST);
+        if(!validateUpdateNote(request)) throw new GeneralException(Code.BAD_REQUEST);
         ReadingRecord readingRecord = findReadingRecord(recordId, userSeq);
         Note note = noteRepository.findByNoteSeqAndReadingRecord(noteId, readingRecord)
                 .orElseThrow(() -> new GeneralException(Code.NOTE_NOT_FOUND));


### PR DESCRIPTION
- 수정시엔 content와 title 둘중하나가 필수이지 않아도 됨
- 다만 현재는 수정시 둘다 비워버리는 행위가 가능하므로 나중에 수정할 필요가 있음