### PR TITLE
[Refactor/145] 로그인 및 회원가입 인증 흐름 리팩토링 및 쿠키 설정 개선

### DIFF
--- a/src/docs/asciidoc/oauth2-api.adoc
+++ b/src/docs/asciidoc/oauth2-api.adoc
@@ -1,12 +1,20 @@
 [[oauth2-api]]
 == 🔑 OAuth2 소셜 로그인 API
 소셜 로그인(카카오, 구글, 애플)을 지원합니다.
-(1) 인증서버 URI먼저 반환받고, 리디렉션 한 뒤 로그인 진행
-(2) 로그인 완료 후 응답으로 오는 객체에 맞춰 회원가입 or 홈으로 진행해주시면 됩니다.
+
+OAuth2 로그인은 다음과 같은 흐름으로 진행됩니다:
+
+. 인가 요청 → 인증서버 리다이렉트
+. 로그인 완료 후 콜백 수신 → 기존 유저 여부 판별
+- (3-a) 기존 유저: refresh_token(30일), device_code(30일)이 쿠키에 설정됨 -> /refresh호출해서 accesss-token 획득
+- (3-b) 신규 유저: `preSignupId(15분)` 쿠키 설정 → 별도 회원가입 API 호출하여 (3-a)흐름 따라감
+
+---
 
 === 소셜 로그인 인가 요청
-사용자가 로그인 버튼을 누르면 해당 URI로 리다이렉트합니다. +
-provider의 값을 kakao / google / apple로 바꾸어서 요청하면 됩니다.
+
+소셜 로그인 버튼 클릭 시 해당 URI로 리디렉션합니다. +
+provider는 `kakao`, `google`, `apple` 중 선택 가능합니다.
 
 [discrete]
 ==== 요청
@@ -15,45 +23,42 @@ include::{snippets}/auth/oauth2-authorize/query-parameters.adoc[]
 
 [discrete]
 ==== 응답
+해당 provider의 인증 서버 URI(로그인화면)로 자동 리다이렉트(302)됩니다.
 include::{snippets}/auth/oauth2-authorize/http-response.adoc[]
-include::{snippets}/auth/oauth2-authorize/response-fields-data.adoc[]
 
 
-=== 소셜 로그인 콜백
+---
 
-[discrete]
-==== 응답 예시
+=== 소셜 로그인 콜백 (기존/신규 유저 분기)
 
-.기존유저 응답(홈화면으로 이동)
-[source,json]
-----
-{
-  "status": "EXISTING_USER",
-  "accessToken": "..."
-}
-----
-
-.새로운유저 응답(회원가입으로 이동)
-[source,json]
-----
-# 쿠키에 DEVICE_CODE 및 REFRESH_TOKEN이 셋팅됨(30 Days 영구쿠키)
-{
-  "status": "SIGNUP_REQUIRED",
-  "preSignupId": 3
-}
-----
-
+로그인 인증을 마치면 인증서버가 자동으로 백엔드 콜백으로 리다이렉트합니다. +
+따라서 응답만 확인하시면 됩니다.
 
 [discrete]
-==== 실제 응답
+==== 요청
+include::{snippets}/auth/oauth2-callback/http-request.adoc[]
+include::{snippets}/auth/oauth2-callback/query-parameters.adoc[]
+include::{snippets}/auth/oauth2-callback/path-parameters.adoc[]
 
+[discrete]
+==== 응답 방식
+
+리다이렉트 형태로 응답되며, 다음 중 하나의 쿠키와 함께 프론트엔드로 이동합니다.
 include::{snippets}/auth/oauth2-callback/http-response.adoc[]
-include::{snippets}/auth/oauth2-callback/response-fields-data.adoc[]
 
+.기존유저 응답
+- 302 리다이렉트 to `https://{front-uri}/auth?status=EXISTING_USER`
+- 쿠키: `refresh_token(30일)`, `device_code(30일)` 포함
+
+.신규유저 응답
+- 302 리다이렉트 to `https://{front-uri}//auth?status=SIGNUP_REQUIRED`
+- 쿠키: `pre_signup_id(15분)` 포함
+
+---
 
 === 회원가입 요청
 
-소셜 로그인 후 `SIGNUP_REQUIRED` 상태로 받은 `preSignupId`를 활용해 회원가입을 진행합니다.
+신규유저인 경우 `preSignupId`가 쿠키로 전달되며, 이 값을 기반으로 회원가입 요청을 합니다.
 
 [discrete]
 ==== 요청
@@ -62,8 +67,25 @@ include::{snippets}/auth/oauth2-signup/request-fields.adoc[]
 
 [discrete]
 ==== 응답
----
-쿠키에 DEVICE_CODE 및 REFRESH_TOKEN이 셋팅됨(30 Days 영구쿠키)
+
+쿠키에 `refresh_token(30일)`, `device_code(30일)`가 설정되며, 별도 응답 본문은 없습니다.
 
 include::{snippets}/auth/oauth2-signup/http-response.adoc[]
-include::{snippets}/auth/oauth2-signup/response-fields-data.adoc[]
+include::{snippets}/auth/oauth2-signup/response-fields-headers.adoc[]
+
+---
+
+=== 액세스 토큰 재발급
+
+쿠키에 저장된 `refresh_token`을 기반으로 새로운 `accessToken`을 발급받습니다. +
+만약 refresh_token의 기한이 3일 미만이라면 자동 갱신됩니다.
+
+[discrete]
+==== 요청
+include::{snippets}/auth/refresh/http-request.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/auth/refresh/http-response.adoc[]
+include::{snippets}/auth/refresh/response-fields-data.adoc[]

--- a/src/main/java/com/boggle_boggle/bbegok/controller/OAuth2AuthController.java
+++ b/src/main/java/com/boggle_boggle/bbegok/controller/OAuth2AuthController.java
@@ -1,6 +1,7 @@
 package com.boggle_boggle.bbegok.controller;
 
 import com.boggle_boggle.bbegok.config.properties.AppProperties;
+import com.boggle_boggle.bbegok.config.properties.CorsProperties;
 import com.boggle_boggle.bbegok.dto.OAuthLoginResponse;
 import com.boggle_boggle.bbegok.dto.base.DataResponseDto;
 import com.boggle_boggle.bbegok.dto.request.SignupRequest;
@@ -19,8 +20,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -36,6 +40,7 @@ public class OAuth2AuthController {
     private final QueryService queryService;
     private final UserService userService;
     private final OAuth2RedirectUriBuilder oAuth2RedirectUriBuilder;
+    private final CorsProperties corsProperties;
 
     //회원가입
     @PostMapping("/signup")
@@ -52,31 +57,69 @@ public class OAuth2AuthController {
 
     //리다이렉트할 인증서버URI를 리턴
     @GetMapping("/oauth2/authorize")
-    public void authorize(@RequestParam("provider") ProviderType providerType, HttpSession session,
+    public void authorize(@RequestParam("provider") ProviderType providerType,
+                          @RequestParam("redirect") String redirectFront, HttpSession session,
                                                           HttpServletResponse response) throws IOException {
+        List<String> origins = Arrays.stream(corsProperties.getAllowedOrigins().split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+
+        if (origins.stream().noneMatch(redirectFront::startsWith)) {
+            response.sendError(400, "invalid front url");
+            return;
+        }
+
+        //리다이렉트 URI 및 csrf방지 state를 세션에 저장
         String state = UUID.randomUUID().toString();
         session.setAttribute("oauth2_state", state);
+        session.setAttribute("redirect_front", redirectFront);
 
         String redirectUrl = oAuth2RedirectUriBuilder.buildRedirectUri(providerType, state);
         response.sendRedirect(redirectUrl); // 실제 리디렉션
-        //return DataResponseDto.of(Map.of("redirectUrl", redirectUrl));
     }
 
-    //oauth 인증서버에서 인가코드를 리다이렉트(302)하는 콜백 API
+    //oauth 인증서버의 콜백 API
     @GetMapping("/oauth2/callback/{provider}")
     public DataResponseDto<OAuthLoginResponse> oauth2Callback(
             @PathVariable("provider") ProviderType providerType,
             @RequestParam("code") String code,
             @RequestParam(name="state", required = false) String state,
             HttpServletRequest request,
-            HttpServletResponse response) {
+            HttpServletResponse response) throws IOException {
         OauthValidateUtil.validateState(request, state);
         OAuthLoginResponse oauthLoginResponse = oauth2LoginService.processOAuth2Callback(providerType, code, state);
         if(oauthLoginResponse.getStatus() == SignStatus.EXISTING_USER) {
             queryService.setLoginCookie(request, response, oauthLoginResponse);
             oauthLoginResponse.clearLoginData();
         }
-        return DataResponseDto.of(oauthLoginResponse);
+        //return DataResponseDto.of(oauthLoginResponse);
+
+        //'auth'페이지로 리디렉션한다.
+        HttpSession session = request.getSession(false);
+        String redirectFront = (session != null)
+                ? (String) session.getAttribute("redirect_front")
+                : null;
+
+        if (redirectFront == null ||
+                corsProperties.getAllowedOrigins().lines().noneMatch(redirectFront::startsWith)) {
+            response.sendError(400, "invalid front url");
+        }
+
+        if (session != null) session.removeAttribute("redirect_front");
+
+        if(oauthLoginResponse.getStatus() == SignStatus.EXISTING_USER) {
+            String frontUrl = UriComponentsBuilder
+                    .fromUriString(redirectFront)   // https://app.bbaegok.store
+                    .path("/auth")                    // /auth
+                    .queryParam("status", r.isNew())     // ?new=true
+                    .queryParam("preSignup", r.isNew())     // ?new=true
+                    .build()
+                    .toUriString();
+        }
+
+           // 인코딩까지 완료
+        response.sendRedirect(frontUrl);
     }
 
     //APPLE(POST) 전용 콜백 API
@@ -92,6 +135,10 @@ public class OAuth2AuthController {
             queryService.setLoginCookie(request, response, oauthLoginResponse);
             oauthLoginResponse.clearLoginData();
         }
+
+        //'auth'페이지로 리디렉션
         return DataResponseDto.of(oauthLoginResponse);
     }
+
+    //accessToken 응답
 }

--- a/src/main/java/com/boggle_boggle/bbegok/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/boggle_boggle/bbegok/dto/OAuthLoginResponse.java
@@ -13,17 +13,18 @@ import net.minidev.json.annotate.JsonIgnore;
 public class OAuthLoginResponse  {
     private SignStatus status;           // SIGNUP_REQUIRED or EXISTING_USER
     private Long preSignupId;  // 회원가입 필요한 경우 발급된 세션 ID
-    private String accessToken;      // 기존회원이면 발급
+    //private String accessToken;      // 기존회원이면 발급
 
     private String refreshToken;
     private String deviceCode;
 
     public static OAuthLoginResponse signupRequired(Long preSignupId) {
-        return of(SignStatus.SIGNUP_REQUIRED, preSignupId, null, null,null);
+        return of(SignStatus.SIGNUP_REQUIRED, preSignupId, null, null);
     }
 
+
     public static OAuthLoginResponse existingUser(String accessToken, String refreshToken, String deviceCode) {
-        return of(SignStatus.EXISTING_USER, null, accessToken, refreshToken, deviceCode);
+        return of(SignStatus.EXISTING_USER, null, refreshToken, deviceCode);
     }
 
     public void clearLoginData() {

--- a/src/main/java/com/boggle_boggle/bbegok/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/boggle_boggle/bbegok/dto/OAuthLoginResponse.java
@@ -10,10 +10,10 @@ import net.minidev.json.annotate.JsonIgnore;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @AllArgsConstructor(staticName = "of")
 @Getter
+@Builder
 public class OAuthLoginResponse  {
     private SignStatus status;           // SIGNUP_REQUIRED or EXISTING_USER
     private Long preSignupId;  // 회원가입 필요한 경우 발급된 세션 ID
-    //private String accessToken;      // 기존회원이면 발급
 
     private String refreshToken;
     private String deviceCode;
@@ -23,7 +23,7 @@ public class OAuthLoginResponse  {
     }
 
 
-    public static OAuthLoginResponse existingUser(String accessToken, String refreshToken, String deviceCode) {
+    public static OAuthLoginResponse existingUser(String refreshToken, String deviceCode) {
         return of(SignStatus.EXISTING_USER, null, refreshToken, deviceCode);
     }
 

--- a/src/main/java/com/boggle_boggle/bbegok/dto/TokenDto.java
+++ b/src/main/java/com/boggle_boggle/bbegok/dto/TokenDto.java
@@ -1,0 +1,15 @@
+package com.boggle_boggle.bbegok.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class TokenDto {
+    String accessToken;
+    String refreshToken;
+    boolean isRefreshUpdated;
+}

--- a/src/main/java/com/boggle_boggle/bbegok/dto/request/SignupRequest.java
+++ b/src/main/java/com/boggle_boggle/bbegok/dto/request/SignupRequest.java
@@ -13,9 +13,6 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class SignupRequest {
-    @NotNull
-    private Long preSignupId;
-
     @NotBlank
     @Size(max = 15)
     private String nickname;

--- a/src/main/java/com/boggle_boggle/bbegok/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/boggle_boggle/bbegok/dto/response/AccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.boggle_boggle.bbegok.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/boggle_boggle/bbegok/exception/Code.java
+++ b/src/main/java/com/boggle_boggle/bbegok/exception/Code.java
@@ -79,7 +79,7 @@ public enum Code {
     TOKEN_NOT_EXPIRED(50006, HttpStatus.UNPROCESSABLE_ENTITY ,"Access token is not expired yet" ),
     REFRESH_COOKIE_NOT_FOUND(50011, HttpStatus.UNAUTHORIZED ,"refresh token not found in cookie" ),
     DEVICE_COOKIE_NOT_FOUND(50014, HttpStatus.UNAUTHORIZED ,"device id not found in cookie" ),
-    INVALID_REFRESH_TOKEN(50008,HttpStatus.UNAUTHORIZED ,  "Invalid Refresh Token, Please Re-sign in."),
+    INVALID_REFRESH_TOKEN(50008,HttpStatus.UNAUTHORIZED ,  "로그인이 만료되었습니다. 재로그인 하세요"),
     INVALID_ACCESS_TOKEN(50005,HttpStatus.UNAUTHORIZED ,  "유효하지 않은 accessToken입니다."),
     EMPTY_COOKIE(50009,HttpStatus.UNAUTHORIZED, "Empty COOKIE"),
     EMPTY_ACCESS_TOKEN(50010,HttpStatus.UNAUTHORIZED, "Access token Empty"),

--- a/src/main/java/com/boggle_boggle/bbegok/utils/CookieUtil.java
+++ b/src/main/java/com/boggle_boggle/bbegok/utils/CookieUtil.java
@@ -25,7 +25,7 @@ public class CookieUtil {
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
-        if (cookies != null && cookies.length > 0) {
+        if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (name.equals(cookie.getName()))  {
                     return Optional.of(cookie);
@@ -47,11 +47,12 @@ public class CookieUtil {
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge, String domain) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")
-                .domain(domain) // 루트도메인: bbaegok.store
-                .sameSite("Lax")
+                //.domain(domain) - staging에선 도메인 제거
+                //.sameSite("Lax") - staging에선 None사용
+                .sameSite("None")
                 .httpOnly(true)
                 .maxAge(maxAge)
-                .secure(true)      // Secure 속성 추가 (HTTPS 필요)
+                .secure(true)
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
@@ -64,8 +65,9 @@ public class CookieUtil {
                 if (name.equals(cookie.getName())) {
                     ResponseCookie deleteCookie = ResponseCookie.from(name, "")
                             .path("/")
-                            .domain(domain)
-                            .sameSite("Lax")
+                            //.domain(domain)
+                            //.sameSite("Lax")
+                            .sameSite("None")
                             .httpOnly(true)
                             .secure(true)
                             .maxAge(0)


### PR DESCRIPTION
### 변경점
- 로그인 콜백 시 쿠키만 셋팅하고, 이후 클라이언트에서 /refresh API로 AccessToken 요청하는 구조로 변경
- 회원가입 분기 처리를 위한 별도 API 작성
- 회원가입 완료 시 RefreshToken 쿠키를 발급하도록 구현
- preSignupId를 HttpOnly 쿠키로 저장하고 회원가입 시 이를 활용하도록 흐름 개선
- 쿠키 domain 지정 및 SameSite 설정 해제로 프론트 로컬 개발 환경에서도 동작 보장
- 변경된 인증 흐름에 맞춰 관련 컨트롤러 및 Spring REST Docs 문서 수정

### 관련 이슈
Ref: #145