### PR TITLE
:recycle: CORS 설정 리팩토링 및 OAuth2 콜백 로그 추가

### DIFF
--- a/src/main/java/com/boggle_boggle/bbegok/config/properties/CorsProperties.java
+++ b/src/main/java/com/boggle_boggle/bbegok/config/properties/CorsProperties.java
@@ -4,13 +4,15 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "cors")
 public class CorsProperties {
-    private String allowedOrigins;
-    private String allowedMethods;
+    private List<String> allowedOrigins;
+    private List<String> allowedMethods;
     private String allowedHeaders;
     private Boolean allowCredentials;
-    private Long maxAge;
+    private Long maxAge = 3600L; // 기본 1시간
 }

--- a/src/main/java/com/boggle_boggle/bbegok/config/security/SecurityConfig.java
+++ b/src/main/java/com/boggle_boggle/bbegok/config/security/SecurityConfig.java
@@ -85,10 +85,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource corsConfigSource = new UrlBasedCorsConfigurationSource();
 
         CorsConfiguration corsConfig = new CorsConfiguration();
+        corsConfig.setAllowCredentials(Boolean.TRUE.equals(corsProperties.getAllowCredentials()));
+        corsConfig.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        corsConfig.setAllowedMethods(corsProperties.getAllowedMethods());
         corsConfig.setAllowedHeaders(Arrays.asList(corsProperties.getAllowedHeaders().split(",")));
-        corsConfig.setAllowedMethods(Arrays.asList(corsProperties.getAllowedMethods().split(",")));
-        corsConfig.setAllowedOrigins(Arrays.asList(corsProperties.getAllowedOrigins().split(",")));
-        corsConfig.setAllowCredentials(corsProperties.getAllowCredentials());
         corsConfig.setMaxAge(corsConfig.getMaxAge());
 
         corsConfigSource.registerCorsConfiguration("/**", corsConfig);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,16 @@ logging.level.com.boggle_boggle.bbegok=INFO
 bbaegok.root-domain=${ROOT_DOMAIN_NAME}
 
 # cors
-cors.allowed-origins=https://localhost:5173,https://${ROOT_DOMAIN_NAME},https://${FRONT_DEV_DOMAIN_NAME},https://appleid.apple.com
-cors.allowed-methods=GET,POST,PUT,PATCH,DELETE,OPTIONS
+cors.allowed-origins[0]=https://localhost:5173
+cors.allowed-origins[1]=https://${ROOT_DOMAIN_NAME}
+cors.allowed-origins[2]=https://${FRONT_DEV_DOMAIN_NAME}
+cors.allowed-origins[3]=https://appleid.apple.com
+cors.allowed-methods[0]=GET
+cors.allowed-methods[1]=POST
+cors.allowed-methods[2]=PUT
+cors.allowed-methods[3]=PATCH
+cors.allowed-methods[4]=DELETE
+cors.allowed-methods[5]=OPTIONS
 cors.allowed-headers=*
 cors.allow-credentials=true
 


### PR DESCRIPTION
- CORS 허용 도메인 설정을 properties 배열로 변경하여 List 형태로 주입
- CORS maxAge를 상수(1시간)로 처리
- OAuth2 콜백 컨트롤러에 디버깅용 로그 추가
- 변경된 CORS 설정에 맞춰 Spring Security config 수정

ref: #145